### PR TITLE
Implement flash storage

### DIFF
--- a/STM32F756ZGTX_FLASH.ld
+++ b/STM32F756ZGTX_FLASH.ld
@@ -37,8 +37,12 @@ _Min_Stack_Size = 0x1000;	/* required amount of stack */
 MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 320K
-  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 1024K
+  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 768K
+  FLASH_CONFIG (r)  : ORIGIN = 0x80C0000,  LENGTH = 256K
 }
+
+__config_start = ORIGIN(FLASH_CONFIG);
+__config_end = ORIGIN(FLASH_CONFIG) + LENGTH(FLASH_CONFIG);
 
 /* Sections */
 SECTIONS

--- a/Src/flash.c
+++ b/Src/flash.c
@@ -28,32 +28,25 @@
 #include "main.h"
 #include "grbl/hal.h"
 
-#define FLASH_SECTOR 1
-#define FLASH_SECTOR_ADDR 0x8008000
-
-static const uint8_t *flash_target = (uint8_t *)FLASH_SECTOR_ADDR;
+extern uint8_t __config_start;
 
 bool memcpy_from_flash (uint8_t *dest)
 {
-    memcpy(dest, flash_target, hal.nvs.size);
+    memcpy(dest, &__config_start, hal.nvs.size);
 
     return true;
 }
 
+
 bool memcpy_to_flash (uint8_t *source)
 {
-   if (!memcmp(source, flash_target, hal.nvs.size))
-        return true;
-
     HAL_StatusTypeDef status = HAL_OK;
-/*
-    if((status = HAL_FLASH_Unlock()) == HAL_OK) {
 
+    if((status = HAL_FLASH_Unlock()) == HAL_OK) {
         static FLASH_EraseInitTypeDef erase = {
-//            .Banks = FLASH_BANK_1,
-            .Sector = FLASH_SECTOR,
             .TypeErase = FLASH_TYPEERASE_SECTORS,
             .NbSectors = 1,
+            .Sector = FLASH_SECTOR_7,
             .VoltageRange = FLASH_VOLTAGE_RANGE_3
         };
 
@@ -62,7 +55,7 @@ bool memcpy_to_flash (uint8_t *source)
         status = HAL_FLASHEx_Erase(&erase, &error);
 
         uint16_t *data = (uint16_t *)source;
-        uint32_t address = (uint32_t)flash_target, remaining = (uint32_t)hal.nvs.size;
+        uint32_t address = (uint32_t)&__config_start, remaining = (uint32_t)hal.nvs.size;
 
         while(remaining && status == HAL_OK) {
             status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, address, *data++);
@@ -73,6 +66,6 @@ bool memcpy_to_flash (uint8_t *source)
 
         HAL_FLASH_Lock();
     }
-*/
+
     return status == HAL_OK;
 }


### PR DESCRIPTION
Tested and working on a STM32F746 board. Uses the last available sector of 256kb, could be changed to the first sector of 32kb for quicker erases but then the main entry pointer would need to be modified