### PR TITLE
Fix serial2 function signatures in serial.c to match grblHAL core

### DIFF
--- a/Src/serial.c
+++ b/Src/serial.c
@@ -1106,9 +1106,9 @@ static void serial2WriteS (const char *s)
 
 // Writes a number of characters from a buffer to the serial output stream, blocks if buffer full
 //
-static void serial2Write (const char *s, uint16_t length)
+static void serial2Write (const uint8_t *s, uint16_t length)
 {
-    char *ptr = (char *)s;
+	const uint8_t *ptr = s;
 
     while(length--)
         serial2PutC(*ptr++);
@@ -1193,7 +1193,7 @@ static bool serial2Disable (bool disable)
     return true;
 }
 
-static bool serial2EnqueueRtCommand (char c)
+static bool serial2EnqueueRtCommand (uint8_t c)
 {
     return enqueue_realtime_command2(c);
 }


### PR DESCRIPTION
This PR resolves compilation errors in the driver by adjusting `serial2` function signatures in `Src/serial.c` to match the type definitions expected by the latest `grblHAL/core` (`grbl/stream.h`).

### Details of Changes:
- **`serial2Write`**: Changed the signature to accept `const uint8_t *s` (instead of `const char *s`) to match the `.write_n` function pointer type in `io_stream_t`.
- **`serial2EnqueueRtCommand`**: Changed the signature to accept `uint8_t c` (instead of `char c`) to match the `.enqueue_rt_command` function pointer type in `io_stream_t`.

### Verification:
The changes were verified and successfully compiled for the **BigTreeTech Octopus Pro v1.1 (STM32H723)** board environment (which shares the same `serial.c` driver implementation as the F7xx upstream).